### PR TITLE
feat: auto-reveal cards when all participants have voted (closes #1)

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -299,6 +299,7 @@ Scrum Poker is inherently real-time and collaborative — full offline play is n
 ### Session Control (Scrum Master)
 
 - **As the SM**, I can click **Reveal** to show everyone's votes at the same time — so no anchoring bias occurs.
+- **As any participant**, when the last eligible online voter casts their vote the cards are **automatically revealed** and the timer stops — so the team never has to wait for the SM to manually reveal when everyone is already done. (Eligible = online, non-SM participants. Rooms with zero eligible voters, e.g. SM-only, are excluded.)
 - **As the SM**, I can click **New Round** to clear all votes and start estimating the next story.
 - **As the SM**, I can enter a Jira issue URL in expanded mode and click **Load** to share the link with all participants — so the team can read the ticket while estimating.
 - **As the SM**, I can clear the shared Jira link — so the link area resets between stories.

--- a/server.js
+++ b/server.js
@@ -288,6 +288,14 @@ wss.on('connection', (ws) => {
           p.voted = true;
           p.value = String(msg.value ?? '');
           room.lastActivity = Date.now();
+
+          // Auto-reveal when every online non-SM participant has voted
+          const eligible = room.participants.filter(p => !p.isSM && p.online !== false);
+          if (eligible.length > 0 && eligible.every(p => p.voted)) {
+            room.cardsRevealed = true;
+            stopTimer(room);
+          }
+
           broadcastRoom(roomName, { type: 'state', data: snapshot(room) });
         }
         break;


### PR DESCRIPTION
## Summary

- **`server.js`** — 7 lines added inside the `vote` handler: after recording a vote, check if every online non-SM participant has voted; if so, set `cardsRevealed = true`, call `stopTimer()`, and broadcast — same single round-trip as a normal vote.
- **`REQUIREMENTS.md`** — new user story added under *Session Control (Scrum Master)*.

## Why

Issue #1 — the SM had to manually click Reveal even when every participant had already voted, adding unnecessary friction to every round.

## Behaviour

| Scenario | Result |
|---|---|
| Last eligible voter casts their vote | Cards auto-revealed, timer stopped, state broadcast |
| Partial vote (not everyone voted yet) | No change — works as before |
| SM-only room (0 eligible voters) | No auto-reveal (guarded by `eligible.length > 0`) |
| Offline participants | Excluded from the eligible set (`online !== false`) |
| SM votes (SM is not eligible) | No effect on auto-reveal logic |
| New round after auto-reveal | `cardsRevealed` resets correctly via existing `newRound` handler |

## Tests

All 4 automated WebSocket tests passed locally:
- ✅ 1/2 voted → not revealed
- ✅ 2/2 voted → auto-revealed, correct values on both participants
- ✅ Timer stops on auto-reveal
- ✅ SM-only room → no auto-reveal
- ✅ `newRound` resets state correctly

## Reviewer notes

No client-side changes required — the auto-reveal arrives as a normal `state` broadcast with `cardsRevealed: true`, which the Angular component already handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)