### PR TITLE
feat: add 40 and 100 story point cards (closes #3)

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -60,7 +60,7 @@ Role is self-selected at registration (no authentication required).
 
 ## Card Deck
 
-- **Fibonacci sequence**: `1, 2, 3, 5, 8, 13, 21, ?, ☕`
+- **Card deck**: `1, 2, 3, 5, 8, 13, 21, 40, 100, ?, ☕` — standard Fibonacci plus 40 and 100 for larger stories/epics
 - Cards are displayed as a compact single horizontal row, always visible.
 - Clicking a card casts/changes the vote.
 - Selected card is highlighted (lifted, accent border).
@@ -290,7 +290,7 @@ Scrum Poker is inherently real-time and collaborative — full offline play is n
 
 ### Voting
 
-- **As a participant**, I can click any card in the Fibonacci row (`1 2 3 5 8 13 21 ? ☕`) to cast or change my vote — so estimation is a single click.
+- **As a participant**, I can click any card in the deck (`1 2 3 5 8 13 21 40 100 ? ☕`) to cast or change my vote — so estimation is a single click.
 - **As a participant**, I can click my already-selected card a second time to undo my vote — my chip snaps back to `?` and the vote count drops, as if I never voted.
 - **As a participant**, my selected card is visually highlighted (lifted with an accent border) — so I always know which value I submitted.
 - **As a participant**, cards are disabled after the SM reveals — so I cannot change my vote after reveal.

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -88,7 +88,7 @@ export class AppComponent implements OnInit, OnDestroy {
   private static readonly TOUCH_STACK_BREAKPOINT = 600;
   private static readonly NARROW_TOUCH_COMPACT_H = 208;
 
-  readonly FIBONACCI_CARDS = ['1', '2', '3', '5', '8', '13', '21', '?', '☕'];
+  readonly FIBONACCI_CARDS = ['1', '2', '3', '5', '8', '13', '21', '40', '100', '?', '☕'];
   readonly TIMER_OPTIONS = [
     { label: '30 s',  value: 30 },
     { label: '1 min', value: 60 },


### PR DESCRIPTION
## Summary

Adds **40** and **100** to the card deck for larger stories and epics.

**Before**: `1 2 3 5 8 13 21 ? ☕` (9 cards)
**After**: `1 2 3 5 8 13 21 40 100 ? ☕` (11 cards)

## Changes

- **`src/app/app.component.ts`** — one line: `FIBONACCI_CARDS` array extended with `'40'` and `'100'`
- **`REQUIREMENTS.md`** — deck description and voting user story updated

## Verification

- ✅ All 11 cards render at 38×52 px (desktop)
- ✅ "100" text is 28 px wide — fits in 38 px card with no overflow
- ✅ Average calculation correctly includes 40 and 100 (numeric filter already handles them)
- ✅ `?` and `☕` still excluded from averages
- ✅ Full deck average test: `1+2+3+5+8+13+21+40+100 / 9 = 21.4` ✓

## Reviewer notes

No server changes needed — card values are free-form strings; the server stores whatever value the client sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)