### PR TITLE
Allow participants to change votes after cards are revealed (issue #10)

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -64,7 +64,7 @@ Role is self-selected at registration (no authentication required).
 - Cards are displayed as a compact single horizontal row, always visible.
 - Clicking a card casts/changes the vote.
 - Selected card is highlighted (lifted, accent border).
-- Cards are disabled after the SM reveals.
+- After the SM reveals, participants can still change their vote to reflect new insights gained from the discussion.
 - Corner indices (playing-card style) on each card.
 - Card numbers are muted (`#bdbdbd`, normal weight) at rest — bold dark (`#1F2937`, `font-weight: 700`) when selected, so the chosen value stands out without visual noise at rest.
 
@@ -295,6 +295,7 @@ Scrum Poker is inherently real-time and collaborative — full offline play is n
 - **As a participant**, my selected card is visually highlighted (lifted with an accent border) — so I always know which value I submitted.
 - **As a participant**, cards are disabled after the SM reveals — so I cannot change my vote after reveal.
 - **As a participant**, my vote is restored from the server after a page refresh — so a network blip doesn't lose my selection.
+- **As a participant**, I can change my vote after cards are revealed — so I can reflect new insights gained from the team's discussion.
 
 ### Session Control (Scrum Master)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@angular/router": "^17.3.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
+        "ws": "^8.17.0",
         "zone.js": "~0.14.0"
       },
       "devDependencies": {
@@ -27,8 +28,7 @@
         "@angular/cli": "^17.3.0",
         "@angular/compiler-cli": "^17.3.0",
         "concurrently": "^8.2.0",
-        "typescript": "~5.4.0",
-        "ws": "^8.17.0"
+        "typescript": "~5.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -13012,7 +13012,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/server.js
+++ b/server.js
@@ -284,16 +284,18 @@ wss.on('connection', (ws) => {
         const room = rooms.get(roomName);
         if (!room) break;
         const p = room.participants.find(p => p.name === ws.participantName);
-        if (p && !room.cardsRevealed) {
+        if (p) {
           p.voted = true;
           p.value = String(msg.value ?? '');
           room.lastActivity = Date.now();
 
-          // Auto-reveal when every online non-SM participant has voted
-          const eligible = room.participants.filter(p => !p.isSM && p.online !== false);
-          if (eligible.length > 0 && eligible.every(p => p.voted)) {
-            room.cardsRevealed = true;
-            stopTimer(room);
+          if (!room.cardsRevealed) {
+            // Auto-reveal when every online non-SM participant has voted
+            const eligible = room.participants.filter(p => !p.isSM && p.online !== false);
+            if (eligible.length > 0 && eligible.every(p => p.voted)) {
+              room.cardsRevealed = true;
+              stopTimer(room);
+            }
           }
 
           broadcastRoom(roomName, { type: 'state', data: snapshot(room) });
@@ -305,7 +307,7 @@ wss.on('connection', (ws) => {
         const room = rooms.get(roomName);
         if (!room) break;
         const p = room.participants.find(p => p.name === ws.participantName);
-        if (p && !room.cardsRevealed) {
+        if (p) {
           p.voted = false;
           p.value = null;
           room.lastActivity = Date.now();

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -45,9 +45,8 @@
       @for (card of FIBONACCI_CARDS; track card) {
         <div class="mini-card"
              [class.mc-selected]="selectedCard === card"
-             [class.mc-disabled]="cardsRevealed"
              (click)="selectCard(card)"
-             [matTooltip]="cardsRevealed ? '' : 'Vote ' + card">
+             [matTooltip]="'Vote ' + card">
           <span class="mc-corner mc-tl">{{ card }}</span>
           <span class="mc-val">{{ card }}</span>
           <span class="mc-corner mc-br">{{ card }}</span>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -493,7 +493,6 @@ export class AppComponent implements OnInit, OnDestroy {
   // ── Cards ─────────────────────────────────────────────
 
   selectCard(value: string): void {
-    if (this.cardsRevealed) return;
     if (this.selectedCard === value) {
       this.selectedCard = null;         // optimistic deselect
       this.send({ type: 'unvote' });


### PR DESCRIPTION
Remove the cardsRevealed guard from the server-side vote/unvote handlers
and the client-side selectCard() guard so participants can update their
estimation after reveal. Auto-reveal logic is preserved for pre-reveal
unanimous voting. REQUIREMENTS.md updated to reflect the new behaviour.

https://claude.ai/code/session_01DkJRQtsDSex7ENnpb8fYmT