### PR TITLE
fix: let users log back in with their old name after a silent timeout

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -25,6 +25,7 @@ Role is self-selected at registration (no authentication required).
   - **"as scrum master"** checkbox
 - **Join** button is disabled until both fields are filled. Submits on Enter key.
 - **Duplicate name prevention**: if another active connection already holds the same name in the room, the server rejects the join with a `NAME_TAKEN` error. The name input turns red and an inline error message is shown. The check is connection-based — a disconnected participant (e.g. page refresh) can reclaim their own name.
+- **Same-browser reclaim (client id)**: every browser carries a persistent random `clientId` (localStorage) sent with each `join`. If the connection currently holding the name belongs to the **same browser** (matching `clientId`) — e.g. a stale socket left over after a silent network timeout — the new join **displaces** it instead of being rejected: the old socket is closed with WebSocket code `4000` (*superseded*) and the participant is taken over seamlessly. A displaced window that is still alive (e.g. a duplicate tab) shows *"Session continued in another window."* and returns to the login bar without auto-rejoining. Joins from a **different** browser are still rejected with `NAME_TAKEN`.
 - **One Scrum Master per room**: if the room already has an active SM, a second join with the SM checkbox ticked is rejected with an `SM_TAKEN` error. The inline message names the existing SM: *"&lt;name&gt; is already the Scrum Master in this room."*
 - All three values are persisted in `localStorage` and **pre-filled** on the next page load so the user can rejoin with one click.
 - A **Leave session** button (toolbar) logs the user out; the participant is immediately removed from the room on the server.
@@ -44,7 +45,9 @@ Role is self-selected at registration (no authentication required).
 |---|---|
 | Join (WS `join` message) | Added to room if not present; previous state (vote, SM role, avatar) restored if name already exists |
 | Page refresh / network blip | WS closes; chip immediately fades to 40% opacity (tooltip shows "offline") — participant **stays in the room indefinitely** until they reconnect or log out |
+| Silent connection drop (idle timeout, laptop sleep, NAT reset) | Server **heartbeat** (WS ping every 30 s, `HEARTBEAT_INTERVAL_MS`) terminates sockets that stop answering pongs — within ≤ 2 intervals the participant is marked offline and their name is free again |
 | Reconnect | Vote, SM role, and avatar fully restored — no data loss as long as the server hasn't restarted |
+| Rejoin while a stale socket of the same browser is still open | Stale socket displaced (close code `4000`); participant continues under the new connection — never a duplicate, never `NAME_TAKEN` |
 | Logout (WS `leave` message) | Participant **removed** from room immediately |
 | All participants offline | Room **cleanup timer** starts (default 30 s, configurable via `ROOM_EMPTY_TTL_MS`). Cancelled immediately if anyone reconnects |
 | Cleanup timer expires | Room destroyed — all state lost |
@@ -185,13 +188,14 @@ Total height: 120 px  (fixed, resize-locked in standalone PWA)
 - **State**: In-memory `Map<roomName, RoomState>`.
 - **Timer**: Server-side `setInterval` per room; broadcasts `state` every second and `timerEnd` at zero.
 - **Room cleanup**: Two mechanisms — hourly sweep deletes rooms idle > 10 min (`ROOM_TTL_MS`); per-room timer destroys room 30 s after last participant goes offline (`ROOM_EMPTY_TTL_MS`).
+- **Connection heartbeat**: WS ping every 30 s (`HEARTBEAT_INTERVAL_MS`, env-configurable); a socket that misses one full interval without a pong is terminated. Prevents silently dropped connections from keeping ghost participants "online" and blocking their names.
 - **Status API**: `GET /` returns active room summary (JSON).
 
 ### WebSocket message types
 
 | Direction | Type | Payload |
 |---|---|---|
-| C → S | `join` | `room, name, isSM` |
+| C → S | `join` | `room, name, isSM, avatar, clientId` |
 | C → S | `vote` | `room, value` |
 | C → S | `unvote` | `room` |
 | C → S | `reveal` | `room` |
@@ -207,6 +211,8 @@ Total height: 120 px  (fixed, resize-locked in standalone PWA)
 | S → C | `timerEnd` | full `RoomState` snapshot |
 | S → C | `kicked` | _(no payload — sent only to the removed client)_ |
 
+Additionally, when the same browser re-claims its name from another connection, the displaced socket is closed with WebSocket close code **`4000`** (reason `superseded`) — the client treats this as "session continued elsewhere" and returns to the login bar instead of auto-rejoining.
+
 ---
 
 ## Browser Persistence (localStorage)
@@ -214,8 +220,10 @@ Total height: 120 px  (fixed, resize-locked in standalone PWA)
 | Key | Value |
 |---|---|
 | `scrumPokerUser` | `{ name, room, isSM }` |
+| `scrumPokerAvatar` | base64 JPEG profile photo (64 × 64) |
+| `scrumPokerClientId` | random UUID identifying this browser — sent with every `join` so the server can tell "same user reconnecting" from "different user wants the same name" |
 
-Pre-fills the registration form on reload. Cleared on logout.
+`scrumPokerUser` pre-fills the registration form on reload and is cleared on logout; `scrumPokerAvatar` and `scrumPokerClientId` persist across sessions.
 
 ---
 
@@ -225,7 +233,7 @@ Pre-fills the registration form on reload. Cleared on logout.
 - **UI library**: Angular Material 17 + custom SCSS.
 - **Audio**: Web Audio API — gracefully silent if blocked.
 - **Connection indicator**: Monochrome dot in toolbar (grey = connected, red = reconnecting). No green — keeps the toolbar quiet.
-- **Reconnection**: Auto-reconnects every 2 s after WS close; sends `join` on reconnect.
+- **Reconnection**: Auto-reconnects every 2 s after WS close; sends `join` (with `clientId`) on reconnect — a stale server-side socket from the same browser is displaced automatically, so a dead session can never hold the name hostage.
 - **Browser support**: Modern browsers (Chrome, Firefox, Edge, Safari).
 - **Dev startup**: `npm run dev` starts Angular (port 4200) and Node.js (port 3000) concurrently.
 
@@ -286,6 +294,9 @@ Scrum Poker is inherently real-time and collaborative — full offline play is n
 - **As the SM**, I can click any participant's card (other than my own) to remove them from the session — a confirmation prompt is shown first, the card highlights red on hover as a visual cue, and the participant is immediately removed for all clients.
 - **As a removed participant**, I am shown a "You have been removed from the session" message and returned to the login screen — my session is cleared so I cannot silently rejoin without going through registration again.
 - **As a team**, when a participant closes their tab or loses connectivity their chip dims and shows "offline" — they stay in the room indefinitely so their vote is preserved and they can reconnect at any time without losing state.
+- **As a user whose connection silently timed out**, I can log back in with my **old name** — the server recognises my browser via a persistent client id and replaces the stale connection instead of rejecting the name as "still logged in". *(fixes #13)*
+- **As a team**, participants whose connections died without a proper close are detected by a server heartbeat within about a minute — their chip dims to offline and their name is freed, so no ghost ever stays "online" forever or appears twice.
+- **As a user**, if I open the session in a second window of the same browser under the same name, the newest window wins the session — the older one shows *"Session continued in another window."* and returns to the login bar.
 - **As a team**, when the last participant goes offline the room is automatically destroyed after 30 seconds of being fully empty — so abandoned sessions don't linger on the server.
 
 ### Voting

--- a/server.js
+++ b/server.js
@@ -27,6 +27,7 @@ const rooms = new Map();
 
 const ROOM_TTL_MS       = 10 * 60 * 1000; // 10 minutes idle → sweep
 const ROOM_EMPTY_TTL_MS = 30_000;           // destroy room 30 s after last participant leaves
+const HEARTBEAT_INTERVAL_MS = Number(process.env.HEARTBEAT_INTERVAL_MS) || 30_000; // ping cadence; a socket that misses one full interval is terminated
 
 // emptyRoomTimers: Map<roomName, TimeoutHandle>
 const emptyRoomTimers = new Map();
@@ -211,9 +212,13 @@ const server = http.createServer((req, res) => {
 const wss = new WebSocketServer({ server, path: '/ws' });
 
 wss.on('connection', (ws) => {
-  // ws.roomName and ws.participantName set after 'join'
+  // ws.roomName, ws.participantName and ws.clientId set after 'join'
   ws.roomName        = null;
   ws.participantName = null;
+  ws.clientId        = null;
+  ws.isAlive         = true;
+
+  ws.on('pong', () => { ws.isAlive = true; });
 
   ws.on('message', (raw) => {
     let msg;
@@ -227,17 +232,26 @@ wss.on('connection', (ws) => {
       case 'join': {
         const participantName = String(msg.name ?? '').trim().slice(0, 64);
         const isSM = Boolean(msg.isSM);
+        const clientId = String(msg.clientId ?? '').slice(0, 64);
         if (!participantName || !roomName) break;
 
-        // Reject if another active connection already holds this name in the room
-        const takenByOther = [...wss.clients].some(
+        // Connections that already hold this name in the room
+        const holders = [...wss.clients].filter(
           c => c !== ws && c.readyState === 1 &&
                c.roomName === roomName && c.participantName === participantName
         );
-        if (takenByOther) {
+        // A different client may not take the name; the same browser (matching
+        // clientId) may displace its own leftover socket — e.g. after a silent
+        // network timeout the old connection can linger in OPEN state.
+        if (holders.some(c => !clientId || c.clientId !== clientId)) {
           ws.send(JSON.stringify({ type: 'error', code: 'NAME_TAKEN', name: participantName }));
           break;
         }
+        holders.forEach(c => {
+          c.participantName = null; // its 'close' handler must not touch the participant
+          c.roomName        = null;
+          c.close(4000, 'superseded'); // live duplicate tab returns to login; a dead socket is reaped by the heartbeat
+        });
 
         // Reject if room already has an active SM and this join requests SM role
         if (isSM) {
@@ -255,6 +269,7 @@ wss.on('connection', (ws) => {
 
         ws.roomName        = roomName;
         ws.participantName = participantName;
+        ws.clientId        = clientId;
 
         // Cancel any pending room-destroy timer — someone is (re)joining
         cancelEmptyRoomTimer(roomName);
@@ -426,7 +441,12 @@ wss.on('connection', (ws) => {
     // Mark participant offline — they stay in the room indefinitely until they reconnect
     const room = rooms.get(roomName);
     if (room) {
-      const p = room.participants.find(p => p.name === participantName);
+      // A newer connection may already hold this identity (fast reconnect) — leave it alone
+      const takenOver = [...wss.clients].some(
+        c => c !== ws && c.readyState === 1 &&
+             c.roomName === roomName && c.participantName === participantName
+      );
+      const p = !takenOver && room.participants.find(p => p.name === participantName);
       if (p) {
         p.online = false;
         broadcastRoom(roomName, { type: 'state', data: snapshot(room) });
@@ -438,6 +458,18 @@ wss.on('connection', (ws) => {
 
   ws.on('error', err => console.error('[ws error]', err.message));
 });
+
+// Heartbeat — a silent network drop (idle timeout, sleep, NAT reset) leaves the
+// socket OPEN forever, keeping a ghost participant "online" and blocking its name.
+// Terminating unresponsive sockets fires their 'close' handler, which frees the name.
+const heartbeatTimer = setInterval(() => {
+  wss.clients.forEach(ws => {
+    if (ws.isAlive === false) { ws.terminate(); return; }
+    ws.isAlive = false;
+    ws.ping();
+  });
+}, HEARTBEAT_INTERVAL_MS);
+wss.on('close', () => clearInterval(heartbeatTimer));
 
 const PORT = process.env.PORT ?? 3000;
 server.listen(PORT, () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -232,6 +232,7 @@ export class AppComponent implements OnInit, OnDestroy {
   postTimerElapsed = 0;   // counts up for 10 s after timer hits 0; 0 = inactive
   private warningBeeped    = false;
   private destroying       = false;
+  private clientId         = '';
   private ws: WebSocket | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private postTimerInterval: ReturnType<typeof setInterval> | null = null;
@@ -251,6 +252,14 @@ export class AppComponent implements OnInit, OnDestroy {
     // Pre-fill room from ?room= invite link
     const urlRoom = new URLSearchParams(location.search).get('room');
     if (urlRoom) this.registerRoom = urlRoom.trim().slice(0, 64);
+
+    // Stable per-browser id — lets the server distinguish "same user reconnecting"
+    // from "different user wants the same name" when a stale connection lingers
+    this.clientId = localStorage.getItem('scrumPokerClientId') ?? '';
+    if (!this.clientId) {
+      this.clientId = crypto.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+      localStorage.setItem('scrumPokerClientId', this.clientId);
+    }
 
     const saved = localStorage.getItem('scrumPokerUser');
     if (saved) {
@@ -290,7 +299,7 @@ export class AppComponent implements OnInit, OnDestroy {
       this.zone.run(() => {
         this.connected = true;
         if (this.isRegistered) {
-          this.send({ type: 'join', room: this.roomName, name: this.userName, isSM: this.isScrumMaster, avatar: this.registerAvatar });
+          this.send({ type: 'join', room: this.roomName, name: this.userName, isSM: this.isScrumMaster, avatar: this.registerAvatar, clientId: this.clientId });
         }
       });
     };
@@ -323,9 +332,17 @@ export class AppComponent implements OnInit, OnDestroy {
       });
     };
 
-    ws.onclose = () => {
+    ws.onclose = (ev) => {
       this.zone.run(() => {
         this.connected = false;
+        if (ev.code === 4000) {
+          // Our name was (re)claimed from another window of this browser — that
+          // session wins; return this one to the login bar instead of rejoining.
+          this.isRegistered = false;
+          this.selectedCard = null;
+          this.snackBar.open('Session continued in another window.', 'OK',
+            { duration: 6000, panelClass: 'snack-warn' });
+        }
         if (!this.destroying) {
           this.reconnectTimer = setTimeout(() => this.connectWS(), 2000);
         }
@@ -464,7 +481,7 @@ export class AppComponent implements OnInit, OnDestroy {
     this.isRegistered  = true;
     if (this.registerAvatar) localStorage.setItem('scrumPokerAvatar', this.registerAvatar);
     localStorage.setItem('scrumPokerUser', JSON.stringify({ name, room, isSM: this.isScrumMaster }));
-    this.send({ type: 'join', room, name, isSM: this.isScrumMaster, avatar: this.registerAvatar });
+    this.send({ type: 'join', room, name, isSM: this.isScrumMaster, avatar: this.registerAvatar, clientId: this.clientId });
   }
 
   shareRoom(): void {


### PR DESCRIPTION
Closes #13.

## Problem

When a connection dies **without a close frame** (idle timeout, laptop sleep, NAT/proxy reset), the server never notices: the socket stays `OPEN` forever. This single defect caused all three symptoms from the issue:

1. The ghost participant keeps showing **"online"** indefinitely.
2. Re-login with the old name is rejected with `NAME_TAKEN` — the name-taken check sees the zombie socket and thinks the user is still logged in.
3. The user is forced to pick a new name and then sees **both names** in the team strip.

## Fix

**Server (`server.js`)**
- **Heartbeat**: WS ping every 30 s (`HEARTBEAT_INTERVAL_MS`, env-configurable); a socket that misses one full interval without a pong is terminated. Ghosts go offline within ≤ 2 intervals and their names are freed — even if the user never returns.
- **Same-browser reclaim**: `join` now carries a persistent per-browser `clientId`. If the name is held by a socket of the *same browser* (the stale pre-timeout connection), the join **displaces** that socket (close code `4000` "superseded") instead of being rejected — so re-login with the old name works immediately, without waiting for the heartbeat. A *different* browser still gets `NAME_TAKEN`, and joins without a `clientId` (old cached bundles) keep the old strict behavior.
- The close handler no longer marks a participant offline when a newer connection has already taken over that identity (prevents the displaced socket from clobbering the fresh session).

**Client (`src/app/app.component.ts`)**
- Generates and persists `scrumPokerClientId` (random UUID) in localStorage; sends it with every `join`.
- On close code `4000`, returns to the login bar with *"Session continued in another window."* instead of auto-rejoining — prevents takeover ping-pong between two windows.

**Spec (`REQUIREMENTS.md`)**
- Documents the heartbeat, same-browser reclaim, the extended `join` payload, close code `4000`, the localStorage keys, and three new user stories.

## Reviewer notes

- **Intentional semantic change**: opening a second window of the *same browser* with the same name now takes over the session (last-window-wins, WhatsApp-Web style) — the displaced window gets a notice and drops to the login bar. Previously it got `NAME_TAKEN`.
- The `clientId` is a displacement credential: 122-bit random UUID, stored only in the owner's localStorage, sent only to the server, never broadcast to other clients. A different client cannot displace a live session.
- Mixed-version deploys are safe both ways (old client ↔ new server tested; new client sends an extra field an old server ignores).
- False-positive heartbeat kills fail soft: the existing 2 s auto-reconnect + reclaim restores the session seamlessly. Browsers answer pings in the network stack, so backgrounded tabs are not at risk.

## Verification

- **WS-level integration test** (spawned real server, raw `ws` clients): 12/12 — the exact issue scenario (zombie socket → re-login with old name succeeds, exactly one online participant, no duplicate), heartbeat reaping, `NAME_TAKEN` still enforced for other clients and legacy joins.
- **Playwright e2e** (headless Chromium, two browser profiles, built app served by `server.js`): 10/10 — clientId persisted, inline error for a different browser, same-browser reclaim after reload, displacement message shown, no flapping over 4.5 s.
- `ng build` clean (bundle-budget warnings pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)